### PR TITLE
Update for lib-pentest-collective

### DIFF
--- a/ansible/roles/liberty_pentest_collective_cc/templates/cc.xml.j2
+++ b/ansible/roles/liberty_pentest_collective_cc/templates/cc.xml.j2
@@ -24,8 +24,9 @@
         <writeDir>${server.config.dir}</writeDir>
     </remoteFileAccess>
 
-        <!-- added 9/29/2021 to use custom cipher list to resolve LUCKY13 vulnerabilities -->
-    <ssl id="defaultSSLConfig" securityLevel="CUSTOM" enabledCiphers="TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 TLS_RSA_WITH_AES_256_GCM_SHA384 TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384 TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384" />
+    <!-- added 9/29/2021 to use custom cipher list to resolve LUCKY13 vulnerabilities -->
+    <!-- added verifyHostname related Dec. 2025;  https://www.ibm.com/support/pages/hostname-verification-liberty -->
+    <ssl id="defaultSSLConfig" verifyHostname="False" skipHostnameVerificationForHosts="${OIDC_CLIENT_REDIRECT}" securityLevel="CUSTOM" enabledCiphers="TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 TLS_RSA_WITH_AES_256_GCM_SHA384 TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384 TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384" />
 
     <basicRegistry id="basic" realm="PentestRealm">
         <user name="adminUser" password="notAPwd4Admin"/>

--- a/ansible/roles/liberty_pentest_collective_ls/tasks/s1_liberty_pentest.yml
+++ b/ansible/roles/liberty_pentest_collective_ls/tasks/s1_liberty_pentest.yml
@@ -79,12 +79,6 @@
       regexp: 'OIDC_SERVER_DISCOVERY'
       line: 'OIDC_SERVER_DISCOVERY=https://{{ cc_hostname }}:9443'
 
-  - name: add server.env cert_defaultKeyStore
-    lineinfile:
-      path: "{{ wlp_usr_dir }}/servers/{{ wl_server }}/server.env"
-      regexp: 'cert_defaultKeyStore'
-      line: 'cert_defaultKeyStore={{ wlp_usr_dir }}/shared/config/server2.der'
-
   - name: add server.env HOST_ALIAS
     lineinfile:
       path: "{{ wlp_usr_dir }}/servers/{{ wl_server }}/server.env"

--- a/ansible/roles/liberty_pentest_collective_ls/tasks/s2_liberty_pentest.yml
+++ b/ansible/roles/liberty_pentest_collective_ls/tasks/s2_liberty_pentest.yml
@@ -13,12 +13,6 @@
      src: "{{ wl_server }}.xml.j2"  
      dest: "{{ wlp_usr_dir }}/servers/{{ wl_server }}/server.xml"
   
-  - name: add server.env cert_defaultKeyStore
-    lineinfile:
-      path: "{{ wlp_usr_dir }}/servers/{{ wl_server }}/server.env"
-      regexp: 'cert_defaultKeyStore'
-      line: 'cert_defaultKeyStore={{ wlp_usr_dir }}/shared/config/server2.der'
-
   - name: add server.env HOST_ALIAS
     lineinfile:
       path: "{{ wlp_usr_dir }}/servers/{{ wl_server }}/server.env"

--- a/ansible/roles/liberty_pentest_collective_ls/templates/s1.xml.j2
+++ b/ansible/roles/liberty_pentest_collective_ls/templates/s1.xml.j2
@@ -25,7 +25,8 @@
 
 
     <!-- added 9/29/2021 to use custom cipher list to resolve LUCKY13 vulnerabilities -->
-    <ssl id="defaultSSLConfig"  securityLevel="CUSTOM" enabledCiphers="TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 TLS_RSA_WITH_AES_256_GCM_SHA384 TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384 TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384" />
+    <!-- added verifyHostname related Dec. 2025;  https://www.ibm.com/support/pages/hostname-verification-liberty -->
+    <ssl id="defaultSSLConfig" verifyHostname="False" skipHostnameVerificationForHosts="${OIDC_SERVER_DISCOVERY}" securityLevel="CUSTOM" enabledCiphers="TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 TLS_RSA_WITH_AES_256_GCM_SHA384 TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384 TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384" />
 
     <basicRegistry id="basic" realm="PentestRealm">
         <user name="adminUser" password="notAPwd4Admin"/>

--- a/ansible/roles/liberty_pentest_collective_ls/templates/s2.xml.j2
+++ b/ansible/roles/liberty_pentest_collective_ls/templates/s2.xml.j2
@@ -3,8 +3,11 @@
 
     <!-- Enable features -->
     <featureManager>
-      <feature>microProfile-6.1</feature>
-      <feature>ldapRegistry-3.0</feature>		
+      <!-- <feature>microProfile-6.1</feature>-->
+      <!-- MP6.1 included mpMetrics-5.1 but MP7.1 requires a separate feature for mpMetrics-5.1 -->
+      <feature>microProfile-7.1</feature>
+      <feature>mpMetrics-5.1</feature>
+      <feature>ldapRegistry-3.0</feature>
       <feature>collectiveMember-1.0</feature>
       <feature>clusterMember-1.0</feature>
     </featureManager>
@@ -17,8 +20,9 @@
     </remoteFileAccess>
 
     
-         <!-- added 9/29/2021 to use custom cipher list to resolve LUCKY13 vulnerabilities -->
-    <ssl id="defaultSSLConfig" securityLevel="CUSTOM" enabledCiphers="TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 TLS_RSA_WITH_AES_256_GCM_SHA384 TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384 TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384" />
+    <!-- added 9/29/2021 to use custom cipher list to resolve LUCKY13 vulnerabilities -->
+    <!-- added verifyHostname related Dec. 2025;  https://www.ibm.com/support/pages/hostname-verification-liberty -->
+    <ssl id="defaultSSLConfig" verifyHostname="False" securityLevel="CUSTOM" enabledCiphers="TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 TLS_RSA_WITH_AES_256_GCM_SHA384 TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384 TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384" />
 
 
     <basicRegistry id="basic" realm="PentestRealm">


### PR DESCRIPTION
Per observation and followup in https://github.ibm.com/was-svt/NEST-OSCert/issues/45, make few update here accordingly.
Regarding server.env, previous `server2.der` setup with `cert_defaultKeyStore` was required in a single server env, but not anymore in current collective env.